### PR TITLE
Include from stb include namespace.

### DIFF
--- a/ray_voxel.cpp
+++ b/ray_voxel.cpp
@@ -26,7 +26,7 @@
 // External libraries for JSON & image loading
 #include "nlohmann/json.hpp"
 #define STB_IMAGE_IMPLEMENTATION
-#include "stb_image.h"
+#include "stb/stb_image.h"
 
 
 


### PR DESCRIPTION
On at least Debian, the stb_image.h header file from the libstb-dev package is in a subdirectory to avoid name space conflicts, switch the include line to use the correct path.