### PR TITLE
Add requirements.txt for clean Python environment setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pybind11
+setuptools
+wheel


### PR DESCRIPTION
This PR adds a `requirements.txt` file to support quick and reproducible Python environment setup using:

```bash
pip install -r requirements.txt
